### PR TITLE
Backport line_ending change to 1.x

### DIFF
--- a/config/set/contao.yaml
+++ b/config/set/contao.yaml
@@ -28,6 +28,8 @@ parameters:
         # We do not require null default values to be nullable (see php71.yaml)
         SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff: ~
 
+    line_ending: "\n"
+
 services:
     PhpCsFixer\Fixer\Comment\HeaderCommentFixer:
         header: "This file is part of Contao.\n\n(c) Leo Feyer\n\n@license LGPL-3.0-or-later"


### PR DESCRIPTION
This PR forces the `line_ending` setting to `\n` rather than `PHP_EOL` also in 1.x (see https://github.com/contao/easy-coding-standard/commit/1f55d3d487957a2f60844dece9d4915eedb653b3). I need this, otherwise I will continue to have line ending shenanigans for my Contao 4.9 PRs ;)