### PR TITLE
Disable PhpUnitExpectationFixer for PHP<8.0

### DIFF
--- a/config/set/contao.php
+++ b/config/set/contao.php
@@ -212,7 +212,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(PhpdocOrderFixer::class);
     $services->set(PhpdocVarAnnotationCorrectOrderFixer::class);
     $services->set(PhpUnitDedicateAssertInternalTypeFixer::class);
-    $services->set(PhpUnitExpectationFixer::class);
     $services->set(PhpUnitMethodCasingFixer::class);
     $services->set(PhpUnitMockFixer::class);
     $services->set(PhpUnitNamespacedFixer::class);
@@ -236,6 +235,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(UselessParenthesesSniff::class);
     $services->set(UselessVariableSniff::class);
     $services->set(VoidReturnFixer::class);
+
+    // Only enable for PHP>=8 (see https://github.com/symplify/symplify/issues/3130)
+    if (PHP_VERSION_ID >= 80000) {
+        $services->set(PhpUnitExpectationFixer::class);
+    }
 
     // Add sniffs from https://github.com/slevomat/coding-standard
     $services->set(DisallowArrayTypeHintSyntaxSniff::class);


### PR DESCRIPTION
This PR is a short-term measure against the following type of errors:

```
In FixerFileProcessor.php line 206:
  Fixing of "calendar-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php" file by "PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer" failed: Id must be an int, got "string".  
   in file […]/tools/ecs/vendor/friendsofphp/php-cs-fixer/src/Tokenizer/Token.php on line 60                                                            
In Token.php line 60:
  Id must be an int, got "string".  
```

It disables the `PhpUnitExpectationFixer` for <= PHP8.0. I'm not too happy with this solution but currently do not see another workaround here. :-/