### PR TITLE
Try to fix the unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,12 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
+              run: |
+                  composer install --no-interaction --no-progress
+                  composer bin phpunit install --no-interaction --no-progress
 
             - name: Run the unit tests
-              run: vendor/bin/phpunit --colors=always
+              run: tools/phpunit/vendor/bin/phpunit --colors=always
 
     prefer-lowest:
         name: Prefer Lowest
@@ -51,10 +53,12 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Install the dependencies
-              run: composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest
+              run: |
+                  composer update --prefer-lowest --prefer-stable --no-interaction --no-progress
+                  composer bin phpunit install --no-interaction --no-progress
 
             - name: Run the unit tests
-              run: vendor/bin/phpunit --colors=always
+              run: tools/phpunit/vendor/bin/phpunit --colors=always
 
     windows:
         name: Windows
@@ -76,7 +80,9 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest --no-progress
+              run: |
+                  composer install --no-interaction --no-progress
+                  composer bin phpunit install --no-interaction --no-progress
 
             - name: Run the unit tests
-              run: vendor/bin/phpunit.bat --colors=always
+              run: tools/phpunit/vendor/bin/phpunit.bat --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /composer.lock
 /vendor/
 
+# Composer bin
+/tools/*/composer.lock
+/tools/*/vendor
+
 # PhpUnit
 /.phpunit.result.cache
 /phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,13 @@
         "symplify/easy-coding-standard": "^9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "bamarni/composer-bin-plugin": "^1.4"
+    },
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": false,
+            "target-directory": "tools"
+        }
     },
     "autoload": {
         "psr-4": {
@@ -37,7 +43,7 @@
             "vendor/bin/ecs check config src tests --config config/self.php --fix --ansi"
         ],
         "unit-tests": [
-            "vendor/bin/phpunit --colors=always"
+            "tools/phpunit/vendor/bin/phpunit --colors=always"
         ]
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.4/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
 >

--- a/tools/phpunit/composer.json
+++ b/tools/phpunit/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "^8.5"
+    }
+}


### PR DESCRIPTION
For some reasons, `symplify/easy-coding-standard` now replaces `friendsofphp/php-cs-fixer`, which breaks our unit tests. https://github.com/symplify/easy-coding-standard/blob/main/composer.json 🤷🏻‍♂️

I have tried to set up `symplify/easy-coding-standard-tester` for two hours, but it kept failing.

```
There was 1 error:

1) Contao\EasyCodingStandard\Tests\AssertEqualsFixerTest::test
Error: Class "Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel" not found

…/easy-coding-standard/vendor/symplify/package-builder/src/Testing/AbstractKernelTestCase.php:213
…/easy-coding-standard/vendor/symplify/package-builder/src/Testing/AbstractKernelTestCase.php:54
…/easy-coding-standard/vendor/symplify/easy-coding-standard-tester/src/Testing/AbstractCheckerTestCase.php:55
```

So I ended up using `composer bin`.