### PR TITLE
Handle getNextMeaningfulToken returning NULL

### DIFF
--- a/src/Fixer/ChainedMethodBlockFixer.php
+++ b/src/Fixer/ChainedMethodBlockFixer.php
@@ -118,7 +118,7 @@ final class ChainedMethodBlockFixer extends AbstractFixer
 
             $nextMeaningful = $tokens->getNextMeaningfulToken($end);
 
-            if ($tokens[$nextMeaningful]->equals('}')) {
+            if (null === $nextMeaningful || $tokens[$nextMeaningful]->equals('}')) {
                 $index = $end;
                 continue;
             }


### PR DESCRIPTION
The screenshotted file below currently fails the parser because there is no meaningful token after the chained method block. It results in a fail with message

```
[ERROR] System error: "Fixing of "./contao/dca/tl_settings.php" file by        
         "Contao\EasyCodingStandard\Fixer\ChainedMethodBlockFixer" failed:      
         Illegal offset type in file                                            
         tools/ecs/vendor/contao/easy-coding-stand
         ard/src/Fixer/ChainedMethodBlockFixer.php on line 121"Run ECS with     
         "--debug" option and post the report here: https://github.com/symplify/symplify/issues/new in
         ./contao/dca/tl_settings.php:159    
```

<img width="920" alt="Bildschirmfoto 2023-10-31 um 12 35 34" src="https://github.com/contao/easy-coding-standard/assets/1073273/af8d3693-e1a5-44af-aeb8-ae61836036da">
