### PR TITLE
Add a conflict with `squizlabs/php_codesniffer` version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "contao/rector": "^1.2",
         "phpunit/phpunit": "^11.5"
     },
+    "conflict": {
+        "squizlabs/php_codesniffer": ">= 4.0.0"
+    },
     "autoload": {
         "psr-4": {
             "Contao\\EasyCodingStandard\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpunit/phpunit": "^11.5"
     },
     "conflict": {
-        "squizlabs/php_codesniffer": ">= 4.0.0"
+        "squizlabs/php_codesniffer": ">=4.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`squizlabs/php_codesniffer` has been released in version 4.0.0, but is incompatible with `symplify/easy-coding-standard` at the moment.

See https://github.com/easy-coding-standard/easy-coding-standard/pull/299.