### PR TITLE
Ensure partial usage of Symfony validator assertions and Doctrine ORM attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.1",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.14",
-        "slevomat/coding-standard": "^8.0",
+        "slevomat/coding-standard": "^8.30",
         "symplify/easy-coding-standard": "^13.0"
     },
     "require-dev": {

--- a/config/contao.php
+++ b/config/contao.php
@@ -186,7 +186,18 @@ return ECSConfig::configure()
     ->withConfiguredRule(PhpdocTypesFixer::class, ['groups' => ['simple', 'meta']])
     ->withConfiguredRule(PhpUnitTestCaseStaticMethodCallsFixer::class, ['call_type' => 'this'])
     ->withConfiguredRule(RandomApiMigrationFixer::class, ['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']])
-    ->withConfiguredRule(ReferenceUsedNamesOnlySniff::class, ['searchAnnotations' => true, 'allowFullyQualifiedNameForCollidingClasses' => true, 'allowFullyQualifiedGlobalClasses' => true, 'allowFullyQualifiedGlobalFunctions' => true, 'allowFullyQualifiedGlobalConstants' => true, 'allowPartialUses' => false])
+    ->withConfiguredRule(ReferenceUsedNamesOnlySniff::class, [
+        'searchAnnotations' => true,
+        'allowFullyQualifiedNameForCollidingClasses' => true,
+        'allowFullyQualifiedGlobalClasses' => true,
+        'allowFullyQualifiedGlobalFunctions' => true,
+        'allowFullyQualifiedGlobalConstants' => true,
+        'allowPartialUses' => false,
+        'namespacesRequiredToUsePartially' => [
+            'Doctrine\ORM\Mapping as ORM',
+            'Symfony\Component\Validator\Constraints as Assert',
+        ],
+    ])
     ->withConfiguredRule(StringImplicitBackslashesFixer::class, ['single_quoted' => 'ignore', 'double_quoted' => 'escape', 'heredoc' => 'escape'])
     ->withConfiguredRule(TrailingCommaInMultilineFixer::class, ['elements' => ['arrays', 'arguments', 'match', 'parameters'], 'after_heredoc' => true])
     ->withConfiguredRule(UnusedUsesSniff::class, ['searchAnnotations' => true])


### PR DESCRIPTION
With my feature contributed in https://github.com/slevomat/coding-standard/pull/1856 we can now make sure that some partial namespaces are not only allowed but enforced to be used the way we want them to 😎 

This config now ensures this usage:

```php
use Doctrine\ORM\Mapping as ORM;
use Symfony\Component\Validator\Constraints as Assert;

#[ORM\Column(type: 'string')]
#[Assert\NotNull]
#[Assert\NotBlank]
private string $myProperty = '';
```